### PR TITLE
Add to the format was originally JSON format support

### DIFF
--- a/callback.js
+++ b/callback.js
@@ -9,7 +9,8 @@ function SafeParseCallback(obj, reviver, callback) {
     var json
 
     try {
-        json = JSON.parse(obj, reviver)
+        var parseData = JSON.stringify(obj);
+        json = JSON.parse(parseData, reviver)
     } catch (err) {
         return callback(err)
     }

--- a/result.js
+++ b/result.js
@@ -6,7 +6,8 @@ function SafeParseTuple(obj, reviver) {
     var json
 
     try {
-        json = JSON.parse(obj, reviver);
+    		var parseData = JSON.stringify(obj);
+        json = JSON.parse(parseData, reviver);
     } catch (err) {
         return Result.Err(err);
     }

--- a/tuple.js
+++ b/tuple.js
@@ -5,7 +5,8 @@ function SafeParseTuple(obj, reviver) {
     var error = null
 
     try {
-        json = JSON.parse(obj, reviver)
+    		var parseData = JSON.stringify(obj);
+        json = JSON.parse(parseData, reviver)
     } catch (err) {
         error = err
     }


### PR DESCRIPTION
parse json data will get error message

First of all thank the author **raynos** for this tool.

``` javascript
var safeParse = require("safe-json-parse/callback");
var a = {
  name:"wowo"
}
safeParse(a,function(error,json){
  if(error){
    // get error operation
  }
})
```

But I tried to solve it myself.

``` javascript
safeParse(JSON.stringify(a),function(error,json){
  if(error){
    // get error operation
  }
})
```

So I improved it.
